### PR TITLE
Fix comment labels

### DIFF
--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.props
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.props
@@ -47,14 +47,14 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <!-- Google Cloud Build
+  <!-- Jenkins
   https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
   -->  
   <PropertyGroup Condition="'$(BUILD_ID)' != '' and '$(BUILD_URL)' != '' ">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <!-- Jenkins
+  <!-- Google Cloud Build
   https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
   -->
   <PropertyGroup Condition="'$(BUILD_ID)' != '' and '$(PROJECT_ID)' != '' ">


### PR DESCRIPTION
The comment labels for Google Cloud Build and Jenkins were the wrong way around.
