### PR TITLE
Feature/msbuild repeatability

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,7 +1,14 @@
 # Documents Index
 
-This repo includes documents that explain how to use and build the product. It also provides detailed information about the project.
+## Reproducible-Dotnetsdk
 
-Here is a good example of this file: https://github.com/dotnet/coreclr/blob/master/Documentation/README.md.
+This folder documents various settings in MSBuild necessary for configuring repeatible builds through isolation.
 
-This is where a TOC goes!
+- [Reproducible MSBuild](./Reproducible-MSBuild/README.md)
+- [Organization](./Reproducible-MSBuild/Organization.md)
+- [Techniques](./Reproducible-MSBuild/Techniques/toc.md)
+- [References](./Reproducible-MSBuild/Introduction.md)
+
+
+
+

--- a/Documentation/Reproducible-MSBuild/Organization.md
+++ b/Documentation/Reproducible-MSBuild/Organization.md
@@ -1,0 +1,18 @@
+# Organization
+
+Each technique is categorized by two qualitative dimensions - Recommendation, and Impact. 
+
+## Recommendation
+
+'Recommendation' characterizes how likely a technique is to pay returns. Generally, any technique documented here is so documented because _someone_, _somewhere_ lost a number of work hours to debugging some non-repeatable build. However, some such issues might be specific to a technique or tool the team is using, so others might never run into that issue. 
+
+- Always: a technique that affects some build behavior that most users will utilize. For instance, resolution of C# framework assemblies.
+- Sometimes: a technique that affects only some infrequently used feature. This technique can generally be skipped if difficult to adopt and your team doesn't use that feature
+- Rarely: a technique that generally doesn't affect users of the msbuild feature it's improving. This technique should generally be skipped unless you face the specific symptoms described in the technique.
+
+## Impact
+'Impact' characterizes how much a technique may interfere with your dev team's workflow. 
+
+- Low: a technique that is generally set once and forget. Developers might not realize it's even there.
+- Medium: developers working on the repo are likely to notice this technique in use, but find it generally easy to learn.
+- High: a technique that negatively impacts developers often enough that many may consider it too much of a hastle to adopt.

--- a/Documentation/Reproducible-MSBuild/README.md
+++ b/Documentation/Reproducible-MSBuild/README.md
@@ -1,0 +1,40 @@
+# Reproducible MSBuild
+
+If you're landing here, you're probable interested in making your builds more repeatable or improve build reliable in some way. This wiki records a number of techniques and tricks for making MSBuild based builds repeatable through isolation from other installed software on your build machines.
+
+This follows a few princples:
+
+## The build should isolate itself from installed software and settings of the host machine
+
+Generally speaking, your repo should describe which build tools it needs, and either install or only use the specific tools and versions that it's configured for. 
+
+> E.g. my build requires Powershell for some custom build steps. Instead of requiring the user to add a specific version of Powershell.exe to the path, I'll instead install it via dotnet tool restore. This also ensures that my build gets the version of Powershell it expects -- Powershell 5.1 to 7.0 is neither forward nor backwards compatible with each other.
+
+## The build should not leave any lasting change on the host machine
+
+Additionally, your build should not leave any cruft behind that could impact the user. Not all repos are following Repeatable Build philosophies -- yet we would still likely to ensure that building our repos don't break the user's other repos on the same machine.
+
+Anything "installed" during your build should be removable by `git clean` on the repo root.
+
+> E.g. my build requires a specific Powershell module for some custom build steps. Rather than installing it into the global or user cache, I configure my build to install it into the `packages/` folder under my repo, and configure `packages/` in `.gitignore`. 
+
+## The repo should be self describing
+
+If your repo has prerequisites, it's often polite to create an init.cmd that locally installs these prerequisites. If not, your README.md should indicate what prerequisites the user must install. 
+
+Additionally, strongly prefer prerequisites that can be installed side-by-side. For instance, the dotnetsdk can be "installed" by adding it to the path and disabling multi-level-lookup. 
+
+> E.g. my README.md instructs users that they need only install dotnetsdk according to the version in global.json, and the repo takes care of everything else. The user can either install it normally, or install it 'standalone'. The build lab always installs it 'standalone' to validate that we can always build with just one version installed.
+
+## Tool versions matter
+
+Every tool used in the build should be pre-configured to support locking to an older version, in case of regression in the build tooling. Regressions include user "bugs" that the build tooling used to accept in a previous reslease.
+
+This guide generally prefers using dotnetsdk over Visual Studio as dotnetsdk's install script supports a -Version argument to easily lock a repo to an earlier sdk version until a regression can be addressed.
+
+> E.g. my global.json is currently configured for 3.1.407 and latestPatch. However, if a new version regresses something, I know I can easily edit global.json to lock it back to 3.1.407 precisely. This unblocks my main branch builds, and gives me time to file a bug against the dotnetsdk for the regression and seek a workaround.
+
+
+
+
+

--- a/Documentation/Reproducible-MSBuild/References.md
+++ b/Documentation/Reproducible-MSBuild/References.md
@@ -1,0 +1,6 @@
+Useful references
+
+# MSBuild
+
+- [MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2019) on msdn
+  - [Customize all .NET builds](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#customize-all-net-builds) lists a number of extensibility points of the default targets that ship with MSBuild.

--- a/Documentation/Reproducible-MSBuild/Techniques/AssemblySearchPaths.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/AssemblySearchPaths.md
@@ -1,0 +1,25 @@
+# AssemblySearchPaths
+
+The `AssemblySearchPaths` MSBuild property controls how MSBuild target `ResolveFrameworkReferences` resolves the location of the selected `TargetFramework` assemblies. By default, old style projects will include the GAC and other outside-of-repo locations that can be impacted by other software that is installed on the developer machine.
+
+- Recommendation: Always
+- Impact: Low
+
+## Usage
+
+In Directory.Build.props
+
+```xml
+<PropertyGroup>
+  <AssemblySearchPaths>
+    {CandidateAssemblyFiles};
+    {HintPathFromItem};
+    {TargetFrameworkDirectory};
+    {RawFileName};
+  </AssemblySearchPaths>
+</PropertyGroup>
+```
+
+## References 
+
+- [MSBuild target framework and target platform](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-target-framework-and-target-platform?view=vs-2019)

--- a/Documentation/Reproducible-MSBuild/Techniques/DisableImplicitNuGetFallbackFolder.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/DisableImplicitNuGetFallbackFolder.md
@@ -1,0 +1,18 @@
+# DisableImplicitNuGetFallbackFolder
+
+By default, Microsoft.NET.NuGetOfflineCache.targets (imported by Microsoft.NET.Sdk.BeforeCommon.targets) will add an extra search path for nuget packages that is not controlled by the user nuget.config. It will add the `sdk/NuGetFallbackFolder` from your dotnet installation to the set of nuget search locations. This could potentially poison your nuget cache between repos, even if you've configured per-repo nuget caches.
+
+
+## Usage
+
+In Directory.Build.props
+
+```xml
+<PropertyGroup>
+  <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+</PropertyGroup>
+```
+
+## References
+- [Microsoft.NET.NuGetOfflineCache.targets](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.NuGetOfflineCache.targets)
+- Official documentation: none?

--- a/Documentation/Reproducible-MSBuild/Techniques/NUGET_XMLDOC_MODE.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/NUGET_XMLDOC_MODE.md
@@ -1,0 +1,26 @@
+# NUGET_XMLDOC_MODE
+
+The environment variable NUGET_XMLDOC_MODE can affect the behavior of nuget restore, both via nuget.exe and via dotnet restore. Make sure this environment variable is cleared, or set to 'none', in order to get default behavior.
+
+The intent of this setting is to omit unpacking xml doc files packaged with some nuget packages. However, it's actual behavior is to suppress all .xml files distributed inside a nuget package, including non-documentation files which may be critical to the nuget package's operation.
+
+- Recommendation: Always
+- Impact: Low
+
+## Usage
+
+In your build system, make sure to clear this environment variable. 
+
+If using Azure DevOps, you can clear the variable with the following additions to your YAML definition:
+
+```yaml
+variables:
+  NUGET_XMLDOC_MODE: ''
+```
+
+Unfortunatelyly there is no way known at this time to override this setting via MSBuild properties. Each developer will need to check if any installed program has overriden this setting.
+
+## Remarks
+
+The dotnet sdk docker image sets NUGET_XMLDOC_MODE=skip ([issue 2790](https://github.com/dotnet/dotnet-docker/issues/2790)), which causes builds run under this docker image to produce results different from a typical developer workstation. Thousands of developers are using this build image for their lab builds in the Azure organization.
+

--- a/Documentation/Reproducible-MSBuild/Techniques/TargetFrameworkRootPath.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/TargetFrameworkRootPath.md
@@ -1,0 +1,34 @@
+# TargetFrameworkRootPath
+
+The "GetReferenceAssemblyPaths" target in "Microsoft.Common.CurrentVersion.targets" resolves from Program Files and Windows Registry where it will search for .net framework reference assemblies (e.g. `<Reference>`).  Instead, recommend utilizing the Microsoft.NETFramework.ReferenceAssemblies nuget instead. Version 1.0.0 of this nuget will provide framework references for all desktop framework versions. 
+
+The `TargetFrameworkRootPath` property lets the user override this process and choose a different location to provide the target framework. By overriding this, we can prevent accidentally picking up target framework installations from registry or program files locations.
+
+- Recommendation: Always
+- Impact: Low
+
+## Usage
+
+In Directory.Build.props
+
+```xml
+<!-- Disable the normal search path mechanism -->
+<PropertyGroup>
+  <TargetFrameworkRootPath Condition="'$(BuildingInsideVisualStudio)'!='true'">[UNDEFINED]</TargetFrameworkRootPath>
+</PropertyGroup>
+<Target Name="CheckTargetFrameworkRootPath" BeforeTargets="GetReferenceAssemblyPaths" Condition="'$(BuildingInsideVisualStudio)'!='true'">
+  <Warning
+    Condition="'$(TargetFrameworkRootPath)' == '[UNDEFINED]' and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
+    Text="Error, TargetFrameworkRootPath not initialized. If you're building for net462 or any other version of desktop NETFramework, please reference the 'Microsoft.NETFramework.ReferenceAssemblies' nuget package and run restore on the project to fix up your framework reference paths." />
+</Target>
+```
+
+## Remarks
+
+Not only does GetReferenceAssemblyPaths rely on installed software, there are different versions of these reference assemblies in the different versions of MSBuild / Visual Studio available. This can result in non-repeatable assembly reference errors (e.g. System.Net.Http appears as version 4.0.0.0 in one version of the net462 reference assemblies, but version 4.2.0.0 in another).
+
+Using the nuget package will produce consistent results regardless of installed reference assemblies, as it overrides the path resolved by GetReferenceAssemblyPaths.
+
+## References
+- [GetReferenceAssemblyPaths task](https://docs.microsoft.com/en-us/visualstudio/msbuild/getreferenceassemblypaths-task?view=vs-2019)
+- Github issue, closed: [TargetFrameworkRootPath not respected](https://github.com/dotnet/msbuild/issues/598)

--- a/Documentation/Reproducible-MSBuild/Techniques/TargetFrameworkRootPath.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/TargetFrameworkRootPath.md
@@ -31,9 +31,11 @@ Alternatively, you may opt to force importing of the Microsoft.NETFramework.Refe
   <TargetFrameworkRootPath Condition="'$(BuildingInsideVisualStudio)'!='true'">[UNDEFINED]</TargetFrameworkRootPath>
 </PropertyGroup>
 <ItemGroup>
-  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" VersionOverride="1.0.0" />
+  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
 </Target>
 ```
+
+Note that if Microsoft.Build.CentralPackageVersions is being used, you will need to change `Version=` to `VersionOverride=`, or move the version value into your Packges.props file.
 
 ## Remarks
 

--- a/Documentation/Reproducible-MSBuild/Techniques/TargetFrameworkRootPath.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/TargetFrameworkRootPath.md
@@ -23,9 +23,21 @@ In Directory.Build.props
 </Target>
 ```
 
+Alternatively, you may opt to force importing of the Microsoft.NETFramework.ReferenceAssemblies package. However, this should only be performed in repos that are no longer using packages.config
+
+```xml
+<!-- Disable the normal search path mechanism -->
+<PropertyGroup>
+  <TargetFrameworkRootPath Condition="'$(BuildingInsideVisualStudio)'!='true'">[UNDEFINED]</TargetFrameworkRootPath>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" VersionOverride="1.0.0" />
+</Target>
+```
+
 ## Remarks
 
-Not only does GetReferenceAssemblyPaths rely on installed software, there are different versions of these reference assemblies in the different versions of MSBuild / Visual Studio available. This can result in non-repeatable assembly reference errors (e.g. System.Net.Http appears as version 4.0.0.0 in one version of the net462 reference assemblies, but version 4.2.0.0 in another).
+Not only does GetReferenceAssemblyPaths rely on installed software, there are different versions of these reference assemblies in the different versions of MSBuild / Visual Studio available. This can result in non-repeatable assembly reference errors (e.g. System.Net.Http appears as version 4.0.0.0 in one version of the net462 reference assemblies, but version 4.2.0.0 in another). This is thought to have behavioral differences.
 
 Using the nuget package will produce consistent results regardless of installed reference assemblies, as it overrides the path resolved by GetReferenceAssemblyPaths.
 

--- a/Documentation/Reproducible-MSBuild/Techniques/toc.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/toc.md
@@ -1,0 +1,4 @@
+- [AssemblySearchPaths](./AssemblySearchPaths.md)
+- [DisableImplicitNuGetFallbackFolder](./DisableImplicitNuGetFallbackFolder.md)
+- [NUGET_XMLDOC_MODE](./NUGET_XMLDOC_MODE.md)
+- [TargetFrameworkRootPath](./TargetFrameworkRootPath.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 ﻿# DotNet.ReproducibleBuilds
 
-This repo generates a package that enables reproducible builds in a single step. It's highly recommended that all projects enable these settings, either via
+This repo generates a package that enables reproducible builds in a single step, and documents MSBuild settings useful for enabling reproducibility through isolation.
+
+This repo documents various MSBuild settings for reproducibilty, and providing a nuget package for enabling some of these setting.
+
+## Documentation
+
+See [Documentation/README.md](Documentation/README.md) for documentation on how to configure 
+
+It's highly recommended that most projects enable these settings as described in the above documentation and usage section.
+
+## DotNet.ReproducibleBuilds nuget package
+
+It's highly recommended that all projects enable these settings, either via
 adding this package or manually as described here: https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
 
 This package sets the following properties:
@@ -14,7 +26,7 @@ It also adds SourceLink dependencies for all repo types (the right one will be u
 
 For more information on debugging with Source Link is [here](https://devblogs.microsoft.com/dotnet/improving-debug-time-productivity-with-source-link/).
 
-## Usage
+### Usage
 
 Add the following to your `Directory.Build.props` file so all projects in your solution have the package added -- use the latest package version.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repo generates a package that enables reproducible builds in a single step,
 
 This repo documents various MSBuild settings for reproducibilty, and providing a nuget package for enabling some of these setting.
 
-## Documentation
+## Build Isolation Documentation
 
-See [Documentation/README.md](Documentation/README.md) for documentation on how to configure 
+See [Reproducible-MSBuild/Techniques/toc.md](Documentation/Reproducible-MSBuild/Techniques/toc.md) for a list of techniques to improve isolation of your builds from the host machine's configuration.
 
 It's highly recommended that most projects enable these settings as described in the above documentation and usage section.
 


### PR DESCRIPTION
Adds documentation for configuring dotnetsdk/msbuild for reproducibility across developer vs lab machines, via isolation from installed software on the machine.