### PR TITLE
Add JetBrains Space environment URL to set ContinuousIntegrationBuild flag

### DIFF
--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.props
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.props
@@ -68,4 +68,11 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <!-- JetBrains Space
+  https://www.jetbrains.com/help/space/automation-environment-variables.html#general
+  -->
+  <PropertyGroup Condition="'$(JB_SPACE_API_URL)' != '' ">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Sets the `ContinuousIntegration` flag when Space automation is used for CI.
https://www.jetbrains.com/help/space/automation-environment-variables.html#general