### PR TITLE
Add support for transitive reference

### DIFF
--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.nuspec
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.nuspec
@@ -21,10 +21,10 @@
   </metadata>
   <files>
     <file src="DotNet.ReproducibleBuilds.props" target="build\DotNet.ReproducibleBuilds.props" />
-    <file src="DotNet.ReproducibleBuilds.props" target="buildMultiTargeting\DotNet.ReproducibleBuilds.props" />
-    <file src="DotNet.ReproducibleBuilds.props" target="buildTransitive\DotNet.ReproducibleBuilds.props" />
+    <file src="DotNet.ReproducibleBuilds.shim.props" target="buildMultiTargeting\DotNet.ReproducibleBuilds.props" />
+    <file src="DotNet.ReproducibleBuilds.shim.props" target="buildTransitive\DotNet.ReproducibleBuilds.props" />
     <file src="DotNet.ReproducibleBuilds.targets" target="build\DotNet.ReproducibleBuilds.targets" />
-    <file src="DotNet.ReproducibleBuilds.targets" target="buildMultiTargeting\DotNet.ReproducibleBuilds.targets" />
-    <file src="DotNet.ReproducibleBuilds.targets" target="buildTransitive\DotNet.ReproducibleBuilds.targets" />
+    <file src="DotNet.ReproducibleBuilds.shim.targets" target="buildMultiTargeting\DotNet.ReproducibleBuilds.targets" />
+    <file src="DotNet.ReproducibleBuilds.shim.targets" target="buildTransitive\DotNet.ReproducibleBuilds.targets" />
   </files>
 </package>

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.nuspec
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.nuspec
@@ -22,7 +22,9 @@
   <files>
     <file src="DotNet.ReproducibleBuilds.props" target="build\DotNet.ReproducibleBuilds.props" />
     <file src="DotNet.ReproducibleBuilds.props" target="buildMultiTargeting\DotNet.ReproducibleBuilds.props" />
+    <file src="DotNet.ReproducibleBuilds.props" target="buildTransitive\DotNet.ReproducibleBuilds.props" />
     <file src="DotNet.ReproducibleBuilds.targets" target="build\DotNet.ReproducibleBuilds.targets" />
     <file src="DotNet.ReproducibleBuilds.targets" target="buildMultiTargeting\DotNet.ReproducibleBuilds.targets" />
+    <file src="DotNet.ReproducibleBuilds.targets" target="buildTransitive\DotNet.ReproducibleBuilds.targets" />
   </files>
 </package>

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.shim.props
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.shim.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="../build/$(MSBuildThisFile)" />
+</Project>

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.shim.targets
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.shim.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="../build/$(MSBuildThisFile)" />
+</Project>


### PR DESCRIPTION
The props/targets files are not imported automatically when the package is referenced transitively. Copying the props/targets files to `buildTransitive/` should be enough to support transitive reference.

The main reason for this change is to allow creating meta-packages. These packages can reference Dotnet.ReproducibleBuilds and other packages (such as Roslyn Analyzers). Then, you can reference a single package to your projects.

https://github.com/NuGet/Home/wiki/Allow-package--authors-to-define-build-assets-transitive-behavior