### PR TITLE
Add DisableImplicitLibraryPacksFolder

### DIFF
--- a/Documentation/Reproducible-MSBuild/Techniques/DisableImplicitLibraryPacksFolder.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/DisableImplicitLibraryPacksFolder.md
@@ -1,0 +1,18 @@
+# DisableImplicitLibraryPacksFolder
+
+Similar to [`DisableImplicitNuGetFallbackFolder`](./DisableImplicitNuGetFallbackFolder.md), Microsoft.NET.NuGetOfflineCache.targets (imported by Microsoft.NET.Sdk.BeforeCommon.targets) adds an extra search path for nuget packages that is not controlled by the user nuget.config. It will add the `sdk/<version>/FSharp/NuGetFallbackFolder` from your dotnet installation to the set of nuget search locations. At the time of writing, this location is used to distribute the FSharp.Core NuGet package, which is generally referenced by all F# projects (and, transitively, all projects that reference projects and NuGet packages created with F#). This could potentially poison your nuget cache between repos, even if you've configured per-repo nuget caches.
+
+
+## Usage
+
+In Directory.Build.props
+
+```xml
+<PropertyGroup>
+  <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
+</PropertyGroup>
+```
+
+## References
+- [Microsoft.NET.NuGetOfflineCache.targets](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.NuGetOfflineCache.targets)
+- Official documentation: none?

--- a/Documentation/Reproducible-MSBuild/Techniques/DisableImplicitLibraryPacksFolder.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/DisableImplicitLibraryPacksFolder.md
@@ -1,6 +1,6 @@
 # DisableImplicitLibraryPacksFolder
 
-Similar to [`DisableImplicitNuGetFallbackFolder`](./DisableImplicitNuGetFallbackFolder.md), Microsoft.NET.NuGetOfflineCache.targets (imported by Microsoft.NET.Sdk.BeforeCommon.targets) adds an extra search path for nuget packages that is not controlled by the user nuget.config. It will add the `sdk/<version>/FSharp/NuGetFallbackFolder` from your dotnet installation to the set of nuget search locations. At the time of writing, this location is used to distribute the FSharp.Core NuGet package, which is generally referenced by all F# projects (and, transitively, all projects that reference projects and NuGet packages created with F#). This could potentially poison your nuget cache between repos, even if you've configured per-repo nuget caches.
+Similar to [`DisableImplicitNuGetFallbackFolder`](./DisableImplicitNuGetFallbackFolder.md), Microsoft.NET.NuGetOfflineCache.targets (imported by Microsoft.NET.Sdk.BeforeCommon.targets) adds an extra search path for nuget packages that is not controlled by the user nuget.config. It will add the `sdk/<version>/FSharp` from your dotnet installation to the set of nuget search locations. At the time of writing, this location is used to distribute the FSharp.Core NuGet package, which is generally referenced by all F# projects (and, transitively, all projects that reference projects and NuGet packages created with F#). This could potentially poison your nuget cache between repos, even if you've configured per-repo nuget caches.
 
 
 ## Usage

--- a/Documentation/Reproducible-MSBuild/Techniques/toc.md
+++ b/Documentation/Reproducible-MSBuild/Techniques/toc.md
@@ -2,6 +2,7 @@
 
 - [AssemblySearchPaths](./AssemblySearchPaths.md)
 - [DisableImplicitNuGetFallbackFolder](./DisableImplicitNuGetFallbackFolder.md)
+- [DisableImplicitLibraryPacksFolder](./DisableImplicitLibraryPacksFolder.md)
 - [DOTNET_MULTILEVEL_LOOKUP](./DOTNET_MULTILEVEL_LOOKUP.md)
 - [NetCoreTargetingPackRoot](./NetCoreTargetingPackRoot.md)
 - [NUGET_XMLDOC_MODE](./NUGET_XMLDOC_MODE.md)

--- a/src/DotNet.ReproducibleBuilds.Isolated/Sdk/Sdk.props
+++ b/src/DotNet.ReproducibleBuilds.Isolated/Sdk/Sdk.props
@@ -43,9 +43,10 @@
   </PropertyGroup>
 
   <!--
-    Disable the extra implicit nuget package cache provided by dotnetsdk.
+    Disable the extra implicit nuget package caches provided by dotnetsdk.
   -->
   <PropertyGroup>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
As requested by @baronfel in https://github.com/dotnet/fsharp/issues/13678#issuecomment-1219484791

I'm not 100% certain about the wording, but based on comparisons with the implementation of `DisableImplicitNuGetFallbackFolder` I think it's correct.

It is my desire that this should be released fairly quickly. Let me know if that is not possible or desirable, and I will then add `DisableImplicitLibraryPacksFolder` manually to all of my own projects in the meantime.