### PR TITLE
Add version to `DotNet.ReproducibleBuilds.Isolated` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,8 @@ If you check out the same commit with the same SDK version and same nuget feed, 
 Add the following to the top of your projects or to `Directory.Build.props`:
 
 ```xml
-<Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="{TBD}" />
+<Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="1.1.1" />
 ```
-
-Note: fill in the appropriate {TBD} version after the first release.
 
 Tested on MSBuild 16.7 (Latest LTS at time of writing).
 


### PR DESCRIPTION
In the main [README.md](https://github.com/dotnet/reproducible-builds/blob/main/README.md?plain=1#L61) file, the [DotNet.ReproducibleBuilds.Isolated](https://www.nuget.org/packages/DotNet.ReproducibleBuilds.Isolated/1.1.1) version is {TBD} with a note below to replace it after the first release.

This PR is adding the latest version from https://www.nuget.org/packages/DotNet.ReproducibleBuilds.Isolated/1.1.1