### PR TITLE
use new minor version for new release

### DIFF
--- a/src/DotNet.ReproducibleBuilds.Isolated/CHANGELOG.md
+++ b/src/DotNet.ReproducibleBuilds.Isolated/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.2.0]
 
 ### Changed
 

--- a/src/DotNet.ReproducibleBuilds/CHANGELOG.md
+++ b/src/DotNet.ReproducibleBuilds/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.2.0]
 
 ### Added
 

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.csproj
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.csproj
@@ -33,8 +33,7 @@
     <PropertyGroup>
       <CloudBuildNumber>$(BuildVersion)</CloudBuildNumber>
       <Version>$(BuildVersion)</Version>
-      <PackageVersion>$(BuildVersion)</PackageVersion>
-      <NuGetPackageVersion>$(BuildVersionSimple)</NuGetPackageVersion>
+      <PackageVersion>$(BuildVersionSimple)</PackageVersion>
       <AssemblyVersion>$(BuildVersionSimple)</AssemblyVersion>
     </PropertyGroup>
   </Target>

--- a/version.json
+++ b/version.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with rel/vN.N
   ],
-  "nugetPackageVersion":{
+  "nugetPackageVersion": {
     "semVer": 2
   }
 }


### PR DESCRIPTION
And unify the package version for the Dotnet.ReproducibleBuilds package, it was 4-part and that is not great.