### PR TITLE
Bump required SDK to 8+ and remove fixed issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,6 @@
     <PackageOutputPath Condition="'$(Build_ArtifactStagingDirectory)' != ''">
       $(Build_ArtifactStagingDirectory)\packages\</PackageOutputPath>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(MSBuildThisFileDirectory)packages\</PackageOutputPath>
-    <SourceLinkPackageVersion>8.0.0</SourceLinkPackageVersion>
     <NerdbankPackageVersion>3.6.133</NerdbankPackageVersion>
 
     <!-- Packaging properties -->

--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ adding this package or manually as described here: https://devblogs.microsoft.co
 
 This package sets the following properties:
 - `PublishRepositoryUrl` = `true`
-- `EmbedUntrackedSources` = `true`
 - `DebugType` = `embedded`. You can specify `portable` in your project if you prefer, but you'll need to upload that `.snupkg` file too.
-- `IncludePackageReferencesDuringMarkupCompilation` = `true` (enables a fix for WPF)
 - `ContinuousIntegrationBuild` = `true` on CI systems
 
-It also adds SourceLink dependencies for all repo types (the right one will be used automatically).
-
-For more information on debugging with Source Link is [here](https://devblogs.microsoft.com/dotnet/improving-debug-time-productivity-with-source-link/).
+More information on `PublishRepositoryUrl` and debugging with Source Link is [here](https://devblogs.microsoft.com/dotnet/improving-debug-time-productivity-with-source-link/).
 
 ### Usage
 

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.csproj
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.csproj
@@ -11,13 +11,6 @@
     <Description>Enables reproducible build settings</Description>
   </PropertyGroup> 
 
-  <ItemGroup>    
-    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(SourceLinkPackageVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.Bitbucket.Git" Version="$(SourceLinkPackageVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkPackageVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitLab" Version="$(SourceLinkPackageVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="DotNet.ReproducibleBuilds.props" Pack="true" PackagePath="build/" />
     <None Include="DotNet.ReproducibleBuilds.targets" Pack="true" PackagePath="build/" />

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.targets
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.targets
@@ -2,15 +2,6 @@
   <PropertyGroup>
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl Condition=" '$(PublishRepositoryUrl)' == '' ">true</PublishRepositoryUrl>
-
-    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources Condition=" '$(EmbedUntrackedSources)' == '' ">true</EmbedUntrackedSources>
-
-    <!-- Enable WPF projects to process package references so source link works 
-         We only need this enabled for 5.0 SDKs; 6.0 defaults to it on.
-    -->
-    <IncludePackageReferencesDuringMarkupCompilation 
-      Condition=" '$(IncludePackageReferencesDuringMarkupCompilation)' == '' and '$(BundledNETCoreAppTargetFrameworkVersion)' == '5.0' " >true</IncludePackageReferencesDuringMarkupCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RepositoryBranch)' == '' and '$(PublishRepositoryUrl)' == 'true'">
@@ -43,13 +34,13 @@
   </PropertyGroup>  
 
   <PropertyGroup>
-    <_ReproducibleBuildsMSBuildMinVersion>16.10.0</_ReproducibleBuildsMSBuildMinVersion>
+    <_ReproducibleBuildsMSBuildMinVersion>17.8.0</_ReproducibleBuildsMSBuildMinVersion>
   </PropertyGroup>
 
   <Target Name="_ReproducibleBuildsMSBuildVersionCheck"
         Condition=" '$([System.Version]::Parse($(_ReproducibleBuildsMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "
    BeforeTargets="ResolveAssemblyReferences;Build;Rebuild" >
     <Warning
-        Text = "Reproducible builds require MSBuild '$(_ReproducibleBuildsMSBuildMinVersion)' or later. This project is using '$(MSBuildVersion)'. Use .NET SDK 5.0.300 or VS 16.10 or later." />
+        Text = "Reproducible builds require MSBuild '$(_ReproducibleBuildsMSBuildMinVersion)' or later. This project is using '$(MSBuildVersion)'. Use .NET SDK 8.0.100 or VS 17.8 or later." />
   </Target>
 </Project>

--- a/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.targets
+++ b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.targets
@@ -35,12 +35,12 @@
 
   <PropertyGroup>
     <_ReproducibleBuildsMSBuildMinVersion>17.8.0</_ReproducibleBuildsMSBuildMinVersion>
+    <_ReproducibleBuildsMSBuildVersion>$(MSBuildVersion)</_ReproducibleBuildsMSBuildVersion><!-- Store in a non-reserved property for testing -->
   </PropertyGroup>
 
   <Target Name="_ReproducibleBuildsMSBuildVersionCheck"
-        Condition=" '$([System.Version]::Parse($(_ReproducibleBuildsMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "
-   BeforeTargets="ResolveAssemblyReferences;Build;Rebuild" >
-    <Warning
-        Text = "Reproducible builds require MSBuild '$(_ReproducibleBuildsMSBuildMinVersion)' or later. This project is using '$(MSBuildVersion)'. Use .NET SDK 8.0.100 or VS 17.8 or later." />
+    Condition="$([MSBuild]::VersionLessThan($(_ReproducibleBuildsMSBuildVersion), $(_ReproducibleBuildsMSBuildMinVersion)))"
+    BeforeTargets="ResolveAssemblyReferences;Build;Rebuild">
+    <Warning Text="Reproducible builds requires MSBuild '$(_ReproducibleBuildsMSBuildMinVersion)' or later. This project is using '$(_ReproducibleBuildsMSBuildVersion)'. Use .NET SDK 8.0.100 or VS 17.8 or later." />
   </Target>
 </Project>

--- a/tests/DotNet.ReproducibleBuilds.Tests/MinimumVersionTests.cs
+++ b/tests/DotNet.ReproducibleBuilds.Tests/MinimumVersionTests.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+using Microsoft.Build.Utilities.ProjectCreation;
+
+namespace DotNet.ReproducibleBuilds.Tests;
+
+public class MinimumVersionTests : TestBase
+{
+    [Theory]
+    [InlineData("17.7.0", false)]
+    [InlineData("17.8.0", true)]
+    [InlineData("17.9.0", true)]
+    public void BelowMinimumVersionEmitsWarning(string msbuildVersion, bool success)
+    {
+        Dictionary<string, string> globalProperties = new()
+        {
+            ["_ReproducibleBuildsMSBuildVersion"] = msbuildVersion
+        };
+
+        ProjectCreator.Templates
+            .ReproducibleBuildProject(GetRandomFile(".csproj"))
+            .TryBuild(restore: false, target: "_ReproducibleBuildsMSBuildVersionCheck", globalProperties, out bool result, out BuildOutput output);
+
+        result.Should().BeTrue();
+        output.Warnings.Should().HaveCount(success ? 0 : 1);
+    }
+}


### PR DESCRIPTION
Bump the minimum required version of MSBuild to 17.8.0, which corresponds to .NET SDK 8, which will soon be oldest supported version of the SDK (see https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs).

Doing so allows us to clean up / slim down the package:

- Remove our references to SourceLink, since it's now provided by the SDK (reference: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link)
- Remove setting `<EmbedUntrackedSources>` as it's already set to the same value by the SDK (reference: https://github.com/dotnet/sdk/pull/31632/files#diff-0adc92e620c2edfd1285b34be242429af4ff7116be50f6685b146b5c31a4de44R19)
- Remove setting `<IncludePackageReferencesDuringMarkupCompilation>` as it's already set to the same value by the SDK (reference: https://github.com/dotnet/sdk/pull/15465/files#diff-7d043b70287c061ddd2cc5ccc8ad0547b629b0eb9c60f3bce15b3b0f353744b9R26)

I also added unit tests and updated docs.