### PR TITLE
Upgrade MSBuild.ProjectCreation to 18.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="MSBuild.ProjectCreation" Version="17.0.1" />
+    <PackageVersion Include="MSBuild.ProjectCreation" Version="18.0.0" />
     <PackageVersion Include="Polyfill" Version="9.3.4" />
     <PackageVersion Include="xunit.v3" Version="3.2.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/DotNet.ReproducibleBuilds.Isolated.Tests/DotNet.ReproducibleBuilds.Isolated.Tests.csproj
+++ b/tests/DotNet.ReproducibleBuilds.Isolated.Tests/DotNet.ReproducibleBuilds.Isolated.Tests.csproj
@@ -91,4 +91,12 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <!-- net472 only: MSBuild.ProjectCreation 18.0.0's auto-redirect demands System.Text.Json 10.0.0.3
+       exactly, but no VS install ships that patch. Pin STJ so the right DLL is in the bin; redirect
+       its System.Text.Encodings.Web transitive explicitly (autogen misses it). -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.3" />
+    <SuggestedBindingRedirects Include="System.Text.Encodings.Web, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" MaxVersion="10.0.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/tests/DotNet.ReproducibleBuilds.Tests/DotNet.ReproducibleBuilds.Tests.csproj
+++ b/tests/DotNet.ReproducibleBuilds.Tests/DotNet.ReproducibleBuilds.Tests.csproj
@@ -40,4 +40,12 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <!-- net472 only: MSBuild.ProjectCreation 18.0.0's auto-redirect demands System.Text.Json 10.0.0.3
+       exactly, but no VS install ships that patch. Pin STJ so the right DLL is in the bin; redirect
+       its System.Text.Encodings.Web transitive explicitly (autogen misses it). -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.3" />
+    <SuggestedBindingRedirects Include="System.Text.Encodings.Web, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" MaxVersion="10.0.0.3" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
MSBuild.ProjectCreation 17.0.1 transitively brings Microsoft.Build 18.0.2, whose net472 build references the 9.x BCL family. On dev machines that have VS 2026 Insiders installed alongside VS 2022, MSBuildAssemblyResolver picks the highest installed VS via the Setup COM API and loads MSBuild assemblies that were compiled against the 10.x BCL family and causes a TypeLoadException.

Bumping to MSBuild.ProjectCreation 18.0.0 pulls in Microsoft.Build 18.6.3, which references the 10.x BCL family. To absorb those into the test bin we mirror the upstream UnitTests project: pin System.Text.Json to 10.0.3 on net472 and emit a binding redirect.